### PR TITLE
Stop passing unnecessary props to DOM nodes

### DIFF
--- a/packages/react-web3-icons/src/components/DynamicIcon/LoadableIcon.tsx
+++ b/packages/react-web3-icons/src/components/DynamicIcon/LoadableIcon.tsx
@@ -3,11 +3,13 @@ import React, { JSX } from "react";
 
 import { Web3IconType } from "../../icons/full";
 import { IconComponentBaseProps, symbolToComponentName } from "../../utils";
+import { omit } from "../../utils/omit";
 import { IconPlaceholder } from "../Base/IconPlaceholder";
 
-export type LoadableIconProps = IconComponentBaseProps & {
+export type LoadableIconProps = Omit<IconComponentBaseProps, "loader"> & {
   iconKey: Web3IconType | string;
   abbreviation: string;
+  fallback: Pick<IconComponentBaseProps, "loader">;
   fallbackComponent?: JSX.Element;
 };
 
@@ -22,7 +24,12 @@ export const LoadableIcon = loadable(
     const mode = mono ? "mono" : "full";
     const componentName = symbolToComponentName(iconKey);
     try {
-      return import(`../icons/${mode}/${componentName}`);
+      const iconEsModule = await import(`../icons/${mode}/${componentName}`);
+      const IconComponent = iconEsModule.default;
+      const imageComponentProps = omit(props, ["fallback"]);
+      return {
+        default: () => <IconComponent {...imageComponentProps} />,
+      };
     } catch (err) {
       if (fallbackComponent) {
         return {

--- a/packages/react-web3-icons/src/components/DynamicIcon/LoadableIcon.tsx
+++ b/packages/react-web3-icons/src/components/DynamicIcon/LoadableIcon.tsx
@@ -9,7 +9,7 @@ import { IconPlaceholder } from "../Base/IconPlaceholder";
 export type LoadableIconProps = Omit<IconComponentBaseProps, "loader"> & {
   iconKey: Web3IconType | string;
   abbreviation: string;
-  fallback: Pick<IconComponentBaseProps, "loader">;
+  fallback?: Pick<IconComponentBaseProps, "loader">;
   fallbackComponent?: JSX.Element;
 };
 

--- a/packages/react-web3-icons/src/utils/omit.ts
+++ b/packages/react-web3-icons/src/utils/omit.ts
@@ -1,0 +1,11 @@
+export const omit = <T extends Record<string, unknown>>(
+  obj: T,
+  keys: (keyof T)[],
+) => {
+  const exclude = new Set(keys);
+  return Object.fromEntries(
+    (Object.entries(obj) as [keyof T, T[keyof T]][]).filter(([key]) => {
+      return !exclude.has(key);
+    }),
+  );
+};


### PR DESCRIPTION
Passing unnecessary props such as `mono` or `iconKey` to dom nodes leads to React warnings:

```
Warning: React does not recognize the `iconKey` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `iconkey` instead. If you accidentally passed it from a parent component, remove it from the DOM element.
```
```
Warning: React does not recognize the `fallbackComponent` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `fallbackcomponent` instead. If you accidentally passed it from a parent component, remove it from the DOM element.
```

Now we filter out all props that do not belong to `<Image />` component